### PR TITLE
AModularAbilityPlayerState now automatically creates the AbilitySystemComponent

### DIFF
--- a/Source/ModularGameplayAbilities/Private/ModularAbilityPlayerState.cpp
+++ b/Source/ModularGameplayAbilities/Private/ModularAbilityPlayerState.cpp
@@ -5,7 +5,7 @@
 
 #include UE_INLINE_GENERATED_CPP_BY_NAME(ModularAbilityPlayerState)
 
-FName AModularAbilityPlayerState::AbilitySystemComponentName(TEXT("AbilitySystemComponentModularAbilitySystemComponent"));
+FName AModularAbilityPlayerState::AbilitySystemComponentName(TEXT("ModularAbilitySystemComponent"));
 
 AModularAbilityPlayerState::AModularAbilityPlayerState(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)

--- a/Source/ModularGameplayAbilities/Private/ModularAbilityPlayerState.cpp
+++ b/Source/ModularGameplayAbilities/Private/ModularAbilityPlayerState.cpp
@@ -5,9 +5,12 @@
 
 #include UE_INLINE_GENERATED_CPP_BY_NAME(ModularAbilityPlayerState)
 
+FName AModularAbilityPlayerState::AbilitySystemComponentName(TEXT("AbilitySystemComponentModularAbilitySystemComponent"));
+
 AModularAbilityPlayerState::AModularAbilityPlayerState(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
+	ModularAbilitySystemComponent = CreateDefaultSubobject<UModularAbilitySystemComponent>(AModularAbilityPlayerState::AbilitySystemComponentName);
 }
 
 UModularAbilitySystemComponent* AModularAbilityPlayerState::GetAbilitySystemComponent() const

--- a/Source/ModularGameplayAbilities/Public/ModularAbilityPlayerState.h
+++ b/Source/ModularGameplayAbilities/Public/ModularAbilityPlayerState.h
@@ -36,6 +36,9 @@ public:
 	bool HasStatTag(FGameplayTag Tag) const;
 
 	void GetLifetimeReplicatedProps(TArray< FLifetimeProperty > & OutLifetimeProps) const;
+public:
+	/*Name of the AbilitySystem component. Use this name if you want to use a different class (with ObjectInitializer.SetDefaultSubobjectClass).*/
+	static FName AbilitySystemComponentName;
 
 private:
 	// The ability system component sub-object used by player characters.


### PR DESCRIPTION
1. AModularAbilityPlayerState now automatically creates the AbilitySystemComponent.

2. This change introduces a static **AbilitySystemComponentName** in AModularAbilityPlayerState to allow users to override the default UModularAbilitySystemComponent with a different subclass by calling ObjectInitializer.SetDefaultSubobjectClass prior to constructor execution.